### PR TITLE
Use custom config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,17 @@ the [JWP Delivery API](https://docs.jwplayer.com/platform/reference/get_apps-con
 The easiest way to maintain configuration files is to use the 'Apps' section in
 your [JWP Dashboard account](https://dashboard.jwplayer.com/).
 
+An example configuration file can be found in
+[`docs/examples/custom-config.json`](examples/custom-config.json). It lists a
+minimal set of playlists that you can replace with your own IDs.
+
+To use this example locally, copy it to
+`platforms/web/public/config.json` and set `defaultConfigSource = /config.json`
+in `.webapp.dev.ini` (and `.webapp.prod.ini` when building for production).
+
+For the playlists to display your media only, make sure each playlist contains
+just the media IDs you want to show.
+
 > See the [web configuration documentation](../platforms/web/docs/web-configuration.md) for configuring the OTT Web App.
 
 ## Available Configuration Parameters
@@ -45,12 +56,12 @@ Use the `menu` array to define the links that are visible in the header and menu
 {
   "menu": [{
     "label": "Movies",
-    "contentId": "lrYLc95e",
-    "filterTags": "Action,Comedy,Drama"
+    "contentId": "mzn2oX3p",
+    "filterTags": "Action,Comedy,Drama",
     "type": "playlist"
   }, {
     "label": "Series",
-    "contentId": "lrYLc95e"
+    "contentId": "zs2OUglZ",
     "type": "playlist"
   }]
 }
@@ -86,14 +97,14 @@ each shelf separately.
 ```
 {
   content: [{
-    "contentId": "lrYLc95e",
-    "featured": true
+    "contentId": "mzn2oX3p",
+    "featured": true,
     "type": "playlist"
   }, {
     "type": "favorites",
-    "title": "Best videos",
+    "title": "Best videos"
   }, {
-    "contentId": "WXu7kuaW"
+    "contentId": "1PC9GvWT",
     "type": "playlist"
   }]
 }
@@ -198,8 +209,8 @@ Use the `features` object to define extra properties for your app.
 ```
 {
   "features": {
-    "recommendationsPlaylist": "IHBjjkSN",
-    "searchPlaylist": "D4soEviP"
+    "recommendationsPlaylist": "mzn2oX3p",
+    "searchPlaylist": "zs2OUglZ"
 }
 ```
 

--- a/docs/examples/custom-config.json
+++ b/docs/examples/custom-config.json
@@ -1,0 +1,30 @@
+{
+  "menu": [
+    { "label": "Playlist 1", "contentId": "mzn2oX3p", "type": "playlist" },
+    { "label": "Playlist 2", "contentId": "zs2OUglZ", "type": "playlist" },
+    { "label": "Playlist 3", "contentId": "1PC9GvWT", "type": "playlist" },
+    { "label": "Playlist 4", "contentId": "nqIWJq6f", "type": "playlist" },
+    { "label": "Playlist 5", "contentId": "GSmD5HuO", "type": "playlist" },
+    { "label": "Playlist 6", "contentId": "owSrVMru", "type": "playlist" },
+    { "label": "Playlist 7", "contentId": "NOdbTdaJ", "type": "playlist" },
+    { "label": "Playlist 8", "contentId": "TKi7Q6z7", "type": "playlist" },
+    { "label": "Playlist 9", "contentId": "dP5Xo3lY", "type": "playlist" }
+  ],
+  "content": [
+    { "contentId": "mzn2oX3p", "featured": true, "type": "playlist" },
+    { "contentId": "zs2OUglZ", "type": "playlist" },
+    { "contentId": "1PC9GvWT", "type": "playlist" },
+    { "contentId": "nqIWJq6f", "type": "playlist" },
+    { "contentId": "GSmD5HuO", "type": "playlist" },
+    { "contentId": "owSrVMru", "type": "playlist" },
+    { "contentId": "NOdbTdaJ", "type": "playlist" },
+    { "contentId": "TKi7Q6z7", "type": "playlist" },
+    { "contentId": "dP5Xo3lY", "type": "playlist" }
+  ],
+  "features": {
+    "recommendationsPlaylist": "mzn2oX3p",
+    "searchPlaylist": "zs2OUglZ",
+    "favoritesList": "1PC9GvWT",
+    "continueWatchingList": "nqIWJq6f"
+  }
+}

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -28,9 +28,10 @@ const env: Env = {
   APP_VERSION: '',
   APP_API_BASE_URL: 'https://cdn.jwplayer.com',
   APP_API_ACCESS_BRIDGE_URL: '',
-  APP_PLAYER_ID: 'M4qoGvUk',
+  APP_PLAYER_ID: '9ycau6FD',
   APP_FOOTER_TEXT: '',
   APP_DEFAULT_LANGUAGE: 'en',
+  APP_DEFAULT_CONFIG_SOURCE: '/config.json',
   APP_PUBLIC_URL: '',
   APP_GTM_LOAD_ON_ACCEPT: false,
 };

--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -1,5 +1,6 @@
 APP_API_BASE_URL=https://cdn.jwplayer.com
-APP_PLAYER_ID=M4qoGvUk
+APP_PLAYER_ID=9ycau6FD
+APP_DEFAULT_CONFIG_SOURCE=/config.json
 
 # page metadata (SEO)
 #APP_NAME=

--- a/platforms/web/ini/.webapp.dev.ini
+++ b/platforms/web/ini/.webapp.dev.ini
@@ -1,5 +1,5 @@
 ; This is a basic Blender demo
-defaultConfigSource = gnnuzabk
+defaultConfigSource = /config.json
 ; When developing, switching between configs is useful for test and debug
 UNSAFE_allowAnyConfigSource = true
 ; Access Bridge service API url host

--- a/platforms/web/ini/.webapp.test.ini
+++ b/platforms/web/ini/.webapp.test.ini
@@ -1,4 +1,4 @@
-defaultConfigSource = gnnuzabk
+defaultConfigSource = /config.json
 additionalAllowedConfigSources[] = kujzeu1b
 additionalAllowedConfigSources[] = ata6ucb8
 additionalAllowedConfigSources[] = nvqkufhy

--- a/platforms/web/ini/templates/.webapp.dev.ini
+++ b/platforms/web/ini/templates/.webapp.dev.ini
@@ -1,4 +1,4 @@
 ; This is a basic Blender demo
-defaultConfigSource = gnnuzabk
+defaultConfigSource = /config.json
 ; When developing, switching between configs is useful for test and debug
 UNSAFE_allowAnyConfigSource = true

--- a/platforms/web/ini/templates/.webapp.prod.ini
+++ b/platforms/web/ini/templates/.webapp.prod.ini
@@ -1,5 +1,5 @@
 ; This is the app config that your application will load at startup
-defaultConfigSource = ; Enter your 8 digit config ID (i.e. gnnuzabk) here (case sensitive)
+defaultConfigSource = /config.json
 
 ; This key ensures proper integration with the JW Platform.
 ; Please make sure to set it here unless you are setting it at build time with the APP_PLAYER_LICENSE_KEY env variable.

--- a/platforms/web/ini/templates/.webapp.test.ini
+++ b/platforms/web/ini/templates/.webapp.test.ini
@@ -1,4 +1,4 @@
-defaultConfigSource = gnnuzabk
+defaultConfigSource = /config.json
 additionalAllowedConfigSources[] = kujzeu1b
 additionalAllowedConfigSources[] = ata6ucb8
 additionalAllowedConfigSources[] = nvqkufhy

--- a/platforms/web/public/config.json
+++ b/platforms/web/public/config.json
@@ -1,0 +1,30 @@
+{
+  "menu": [
+    { "label": "Playlist 1", "contentId": "mzn2oX3p", "type": "playlist" },
+    { "label": "Playlist 2", "contentId": "zs2OUglZ", "type": "playlist" },
+    { "label": "Playlist 3", "contentId": "1PC9GvWT", "type": "playlist" },
+    { "label": "Playlist 4", "contentId": "nqIWJq6f", "type": "playlist" },
+    { "label": "Playlist 5", "contentId": "GSmD5HuO", "type": "playlist" },
+    { "label": "Playlist 6", "contentId": "owSrVMru", "type": "playlist" },
+    { "label": "Playlist 7", "contentId": "NOdbTdaJ", "type": "playlist" },
+    { "label": "Playlist 8", "contentId": "TKi7Q6z7", "type": "playlist" },
+    { "label": "Playlist 9", "contentId": "dP5Xo3lY", "type": "playlist" }
+  ],
+  "content": [
+    { "contentId": "mzn2oX3p", "featured": true, "type": "playlist" },
+    { "contentId": "zs2OUglZ", "type": "playlist" },
+    { "contentId": "1PC9GvWT", "type": "playlist" },
+    { "contentId": "nqIWJq6f", "type": "playlist" },
+    { "contentId": "GSmD5HuO", "type": "playlist" },
+    { "contentId": "owSrVMru", "type": "playlist" },
+    { "contentId": "NOdbTdaJ", "type": "playlist" },
+    { "contentId": "TKi7Q6z7", "type": "playlist" },
+    { "contentId": "dP5Xo3lY", "type": "playlist" }
+  ],
+  "features": {
+    "recommendationsPlaylist": "mzn2oX3p",
+    "searchPlaylist": "zs2OUglZ",
+    "favoritesList": "1PC9GvWT",
+    "continueWatchingList": "nqIWJq6f"
+  }
+}


### PR DESCRIPTION
## Summary
- add public `config.json` referencing provided playlists
- update `.webapp` ini files to load `/config.json`
- set default config path in env files
- document using the local config example

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68552bf9a0f483208bc7abbab977296f